### PR TITLE
fix find predicates which consider undefined values

### DIFF
--- a/__tests__/find.test.js
+++ b/__tests__/find.test.js
@@ -14,4 +14,11 @@ describe('find', () => {
 
     expect(find(predicate)(arr)).toEqual(undefined)
   })
+
+  it('works with predicates which consider undefined values', () => {
+    const arr = [1, undefined, 5, 7, 9]
+    const predicate = x => x === undefined || x > 6
+
+    expect(find(predicate)(arr)).toEqual(undefined)
+  })
 })

--- a/src/find.js
+++ b/src/find.js
@@ -1,10 +1,13 @@
-const find = predicate => arr =>
-  arr.reduce((acc, cur) => {
-    if (acc !== undefined) {
+const nil = {}
+const find = predicate => arr => {
+  const result = arr.reduce((acc, cur) => {
+    if (acc !== nil) {
       return acc
     }
 
     return predicate(cur) ? cur : acc
-  }, undefined)
+  }, nil)
+  return result === nil ? undefined : result;
+}
 
 module.exports = find


### PR DESCRIPTION
Hey, really interesting library! I'm eager to use it, but unfortunately I haven't been able yet because I can't currently afford any donation to a charity against abuse, which the license requires.

However, looking through the code I found a potential problem: The [TC39 specification](https://tc39.es/ecma262/#sec-array.prototype.find) for `Array.prototype.find` states that it should return the first value starting from the beginning that the predicate returns true.

I found an edge case in the current implementation where if the predicate is testing for `undefined` values, this characteristic would fail. I have a specific use case for this:

In my project (which btw, I keep abusing reduce, so this library would be of great help) there's a place where I need to get the first value that's greater than a threshold, but in the arrays of that project I'm using `undefined` as a way of segmenting them (inspired by strings in C, where they use a nil character `\0` to represent the end of a string). So, this specific case:

```js
const getFirstBigRequest = find(x => x === undefined || x > 6);

// ... later on

const result = getFirstBigRequest([1,2,3,undefined,4,5,6,7,8]);
```

I would expect to receive `undefined` as the value, but if I get to use this library, this would break as it would return `7` instead.

This PR addresses this issue, in preparation for the day when I can finally get to use this library 👍 

P.S.: I couldn't run the tests because it would break the license terms as well, so I'm hoping they all pass 🤞 